### PR TITLE
TS ES6 export fix (removes exports field)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prisma-extension-pagination",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prisma-extension-pagination",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.4.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "description": "Prisma Client extension for pagination",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
-  "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/index.module.js"
-  },
   "main": "./dist/index.js",
   "module": "./dist/index.module.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-extension-pagination",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Prisma Client extension for pagination",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Removing the exports field altogether fixes build errors with TS and ES6.

```
import { paginate } from "prisma-extension-pagination";

SyntaxError: Named export 'paginate' not found. The requested module 'prisma-extension-pagination' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:
```

I found the solution here in [an issue](https://github.com/developit/microbundle/issues/1023#issuecomment-1409525970) on the microbundle repo.