### PR TITLE
feat: add support for Prisma Client v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/deptyped/prisma-extension-pagination#readme",
   "peerDependencies": {
-    "@prisma/client": "^4.9.0"
+    "@prisma/client": "^4.9.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",


### PR DESCRIPTION
This commit expands the peer dependencies to include Prisma Client version 5.0.0, while still maintaining compatibility with version 4.9.0. This should help users of prisma-extension-pagination who have upgraded to the newer version of Prisma Client.