### PR TITLE
chore: use @prisma/client/extension import

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client/extension";
 import {
   PageNumberPaginationOptions,
   PageNumberPaginationMeta,


### PR DESCRIPTION
I am currently facing an issue because `@prisma/client/default.js` is imported on my project and I do not use the default output path.

When I patch `prisma-extension-pagination` locally, the issue disappear. 